### PR TITLE
Optimization: Moving cursor does not redraw Grid

### DIFF
--- a/src/components/Cell.js
+++ b/src/components/Cell.js
@@ -4,10 +4,9 @@ const Cell = (props) => {
     let transform = { 
         transform: `scale(${props.flipGlyph}, -1) rotate(${props.rotationAmount}deg)`
     };
-    const highlighted = props.highlighted ? 'selected' : '';
     const clipCells = props.clipCells ? 'clipCells' : '';
     const glyphInvertedColor = props.glyphInvertedColor ? 'invertColor' : '';
-	const classes = `${highlighted} ${clipCells} ${glyphInvertedColor}`;
+	const classes = `${clipCells} ${glyphInvertedColor}`;
 
 	return (
 		<div className={classes} style={{width : props.cellWidth, height : props.cellHeight}} >

--- a/src/components/Cursor.js
+++ b/src/components/Cursor.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+import { observer } from 'mobx-react';
+import store from '../models/CanvasStore';
+
+@observer class Numbers extends Component {
+  render() {
+    return (
+      <div
+        className="cursor"
+        style={{
+        	width: store.cellWidth,
+        	height: store.cellHeight,
+        	top: store.selected_y * store.cellHeight,
+        	left: store.selected_x * store.cellWidth
+        }}
+      />
+    );
+  }
+}
+export default Numbers;

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -3,19 +3,18 @@ import { observer } from 'mobx-react';
 import store from '../models/CanvasStore';
 import Cell from './Cell';
 import SelectionHighlight from './SelectionHighlight'
+import Numbers from './Numbers'
+import Cursor from './Cursor'
 import gridStore from '../models/GridStore'
 
 @observer class Grid extends Component {
 
   render() {
     const canvas = store.canvas
-    const selected_y = store.selected_y;
-    const selected_x = store.selected_x;
     const pixelRendering = store.pixelRendering ? 'pixelRendering' : '';
 
     const grid = canvas.map((row, y) =>
       <div className="row" key={y} style={{width: Number(store.canvasWidth) * Number(store.cellWidth) + 'px', height: Number(store.cellHeight) + 'px'}}>
-        <div className={'rowNum ' + (selected_y === y ? 'highlighted' : '')}>{y + 1}</div>
         {row.map(([glyphPath, svgWidth, svgHeight, svgBaseline, glyphOffsetX, glyphFontSizeModifier, rotationAmount, flipGlyph, glyphInvertedColor], x) =>
           <Cell 
             glyphPath={glyphPath} 
@@ -32,17 +31,10 @@ import gridStore from '../models/GridStore'
             flipGlyph={flipGlyph}
             glyphInvertedColor={glyphInvertedColor}
             clipCells={store.clipCells}
-            highlighted={y === selected_y && x === selected_x} />
+          />
         )}
       </div>
     );
-
-    const colNums = [];
-    for (var i=0; i<store.canvasWidth; i++) {
-        colNums.push(
-          <div key={i} className={'colNum ' + (selected_x === i ? 'highlighted' : '')} style={{width : store.cellWidth}}>{i + 1}</div>
-        )
-    }
 
     return (
       <div id="canvas" className={`grid ${pixelRendering}`} style={{
@@ -54,7 +46,9 @@ import gridStore from '../models/GridStore'
             gridStore.settings.zoom
           })`
       }}>
-        <div className="colNums">{colNums}</div>
+
+        <Numbers />
+        <Cursor />
         {grid}
         <SelectionHighlight />
       </div>

--- a/src/components/Numbers.js
+++ b/src/components/Numbers.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import { observer } from 'mobx-react';
+import store from '../models/CanvasStore';
+
+@observer class Numbers extends Component {
+  render() {
+    const selected_y = store.selected_y;
+    const selected_x = store.selected_x;
+
+    const colNums = [];
+    for (let i=0; i < store.canvasWidth; i++) {
+        colNums.push(
+          <div
+            key={i}
+            className={'colNum ' + (selected_x === i ? 'highlighted' : '')}
+            style={{width : store.cellWidth, height: store.cellHeight}}
+          >
+            {i + 1}
+          </div>
+        )
+    }
+
+    const rowNums = [];
+    for (let i=0; i < store.canvasHeight; i++) {
+        rowNums.push(
+          <div 
+            key={i}
+            className={'rowNum ' + (selected_y === i ? 'highlighted' : '')}
+            style={{width : store.cellWidth, height: store.cellHeight, position: 'absolute', top: i * store.cellHeight}}
+          >
+            {i + 1}
+          </div>
+        )
+    }
+
+    return (
+      <div className="numbers">
+        <div className="colNums">{colNums}</div>
+        <div className="rowNums">{rowNums}</div>
+      </div>
+    );
+  }
+}
+export default Numbers;

--- a/src/models/CanvasStore.js
+++ b/src/models/CanvasStore.js
@@ -26,7 +26,9 @@ class CanvasStore {
 			this.heightPixels = storage.heightPixels
 		//else create empty canvas
 		} else { 
-			this.canvas = Array.from({length: this.canvasHeight}, () => Array.from({length: this.canvasWidth}, () => EMPTY_CELL ));
+			this.canvas = Array.from({length: this.canvasHeight}, () => this.getEmptyRow());
+
+
 			this.widthPixels = this.canvasWidth * this.cellWidth;
 			this.heightPixels = this.canvasHeight * this.cellHeight;
 			localStorage.setItem('firstRun', false)
@@ -134,15 +136,18 @@ class CanvasStore {
 		}
 		this.widthPixels = this.canvasWidth * this.cellWidth;
 	}
+
+	getEmptyRow = () => Array.from({length: this.canvasWidth}, () => EMPTY_CELL)
+
 //Change canvas height
 	@action addRow = () => { 
 		this.canvasHeight = this.canvasHeight + 1;
-		this.canvas.push(Array.from({length: this.canvasWidth}, () => EMPTY_CELL ));
+		this.canvas.push(this.getEmptyRow());
 		this.heightPixels = this.canvasHeight * this.cellHeight;
 	}
 	@action addRowTop = () => { 
 		this.canvasHeight = this.canvasHeight + 1;
-		this.canvas.unshift(Array.from({length: this.canvasWidth}, () => EMPTY_CELL ));
+		this.canvas.unshift(this.getEmptyRow())
 		this.heightPixels = this.canvasHeight * this.cellHeight;
 	}
 	@action deleteRow = () => {
@@ -185,7 +190,7 @@ class CanvasStore {
 //Add row at selection
 	@action addRowAtSelection = () => {
 		this.canvasHeight++;
-		this.canvas.splice(this.selected_y, 0, Array.from({length: this.canvasWidth}, () => EMPTY_CELL ));
+		this.canvas.splice(this.selected_y, 0, this.getEmptyRow());
 		this.heightPixels = this.canvasHeight * this.cellHeight;
 	}
 //Add col at selection
@@ -386,7 +391,7 @@ class CanvasStore {
 		this.defaultFontSize = 30;
 		this.widthPixels = this.canvasWidth * this.cellWidth;
 		this.heightPixels = this.canvasHeight * this.cellHeight;
-		this.canvas = Array.from({length: this.canvasHeight}, () => Array.from({length: this.canvasWidth}, () => EMPTY_CELL ));
+		this.canvas = Array.from({length: this.canvasHeight}, () => this.getEmptyRow());
 	}
 	toggleWriting = () => {
 		this.disableShortcuts = !this.disableShortcuts;

--- a/style.css
+++ b/style.css
@@ -113,9 +113,7 @@ canvas
 	box-shadow: inset 0 0 0 0.5px rgba(255,255,255,0.1);
 	fill: white;
 }
-.canvas_container.darkTheme .row div.selected {
-	box-shadow: inset 0 0 0 1px rgba(255,0,0,1);
-}
+
 .canvas_container.darkTheme .row div.invertColor {
 	fill: black;
 	background: white;
@@ -180,32 +178,25 @@ canvas
 	overflow: visible;
 	position: relative;
 }
-.row div.rowNum {
+.rowNums div.rowNum {
 	position: absolute;
-	top: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	left: -30px;
 	box-shadow: none;
 	text-align: right;
 	font-size: 0.6em;
 	background: none;
-	color:#888;
+	color: #888;
 }
-.row div.rowNum.highlighted {
+.rowNums div.rowNum.highlighted {
 	color: red;
 }
 .row div.clipCells {
 	overflow: hidden;
 }
-.row div.selected:after {
-	content: '';
-	display: block;
-	position: absolute;
-	top:0;
-	left:0;
-	width:100%;
-	height: 100%;
-	box-shadow: inset 0 0 0 1px rgba(255,0,0,0.5);
-}
+
 .colNums {
 	width: 100%;
 	position: relative;
@@ -213,9 +204,9 @@ canvas
 }
 .colNum {
 	width: auto;
-	display: inline-block;
-	vertical-align:top;
-	box-shadow: none;
+	display: inline-flex;
+	justify-content: center;
+	align-items: center;
 	font-size: 0.6em;
 	background: none;
 	color:#888;
@@ -225,7 +216,17 @@ canvas
 .colNum.highlighted {
 	color: red;
 }
-.canvas_container.hideGrid .colNums, .canvas_container.hideGrid .row div.rowNum {
+.cursor {
+	position: absolute;
+    box-shadow: inset 0 0 0 1px rgba(255,0,0,0.5);
+	z-index: 1000;
+}
+
+.canvas_container.hideGrid .cursor {
+	display: none;
+}
+
+.canvas_container.hideGrid .colNums, .canvas_container.hideGrid .rowNums {
 	display: none;
 }
 .selectionHighlight {
@@ -238,9 +239,7 @@ canvas
 .canvas_container.hideGrid .row div, .canvas_container.hideGrid.darkTheme .row div {
 	box-shadow: inset 0 0 0 0 rgba(0,0,0,0);
 }
-.canvas_container.hideGrid .row div.selected:after, .canvas_container.hideGrid.darkTheme .row div.selected:after {
-	box-shadow: inset 0 0 0 0 rgba(0,0,0,0);
-}
+
 svg {
 	overflow: visible;
 	transform-origin: 50% 50%;


### PR DESCRIPTION
The grid component referenced selected_x and selected_y. This led
to the grid being rendered each time either one of them changes,
ie. when the cursor is moved. When the canvas is large this leads
to frustrating lag.

This commit extracts the row and column numbers, as well as the
cursor to separate components outside the grid component, leading
to moving around being fast :)